### PR TITLE
Laravel 8 Compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.4",
         "spatie/laravel-dashboard": "^2.0",
-        "themsaid/forge-sdk": "^2.1"
+        "themsaid/forge-sdk": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"


### PR DESCRIPTION
Old themsaid/forge-sdk required guzzlehttp/guzzle 6.0. Preventing use with Laravel 8.

The new version works with 6.3.1|^7.0. Allowing this package to be used with the new Laravel 8.